### PR TITLE
feat: rough code for left shift

### DIFF
--- a/src/boolify.rs
+++ b/src/boolify.rs
@@ -88,7 +88,7 @@ pub fn boolify(arith_circuit: &BristolCircuit, bit_width: usize) -> BristolCircu
                 "ABitAnd" => ValueWire::bit_and(a, b),
                 "ABitOr" => ValueWire::bit_or(a, b),
                 "AXor" => ValueWire::bit_xor(a, b),
-                "AShiftL" => panic!("Not implemented: shl"), // TODO
+                "AShiftL" => ValueWire::bit_shl(a, b),
                 "AShiftR" => panic!("Not implemented: shr"), // TODO
                 _ => unreachable!(),
             });

--- a/src/boolify.rs
+++ b/src/boolify.rs
@@ -89,7 +89,7 @@ pub fn boolify(arith_circuit: &BristolCircuit, bit_width: usize) -> BristolCircu
                 "ABitOr" => ValueWire::bit_or(a, b),
                 "AXor" => ValueWire::bit_xor(a, b),
                 "AShiftL" => ValueWire::bit_shl(a, b),
-                "AShiftR" => panic!("Not implemented: shr"), // TODO
+                "AShiftR" => ValueWire::bit_shr(a, b),
                 _ => unreachable!(),
             });
         } else {

--- a/src/value_wire.rs
+++ b/src/value_wire.rs
@@ -182,10 +182,17 @@ impl ValueWire {
             return ValueWire::new_const(0, &self.id_gen);
         }
 
-        let mut bits = Vec::with_capacity(self.bits.len() - amount);
+        let mut bits = Vec::with_capacity(self.bits.len());
 
         for i in amount..self.bits.len() {
             bits.push(self.bits[i].clone());
+        }
+
+        for _ in 0..amount {
+            bits.push(Rc::new(BoolWire {
+                id_gen: self.id_gen.clone(),
+                data: BoolData::Const(false),
+            }));
         }
 
         ValueWire {

--- a/src/value_wire.rs
+++ b/src/value_wire.rs
@@ -58,6 +58,24 @@ impl ValueWire {
         }
     }
 
+    pub fn as_usize(&self) -> Option<usize> {
+        if self.bits.len() > (usize::BITS as usize) {
+            return None;
+        }
+
+        let mut value = 0;
+
+        for i in 0..self.bits.len() {
+            let BoolData::Const(bit) = self.bits[i].data else {
+                return None;
+            };
+
+            value |= (bit as usize) << i;
+        }
+
+        Some(value)
+    }
+
     pub fn at(&self, index: usize) -> Rc<BoolWire> {
         if index < self.bits.len() {
             self.bits[index].clone()
@@ -355,6 +373,13 @@ impl ValueWire {
             bits: (0..size)
                 .map(|i| BoolWire::xor(&a.at(i), &b.at(i)))
                 .collect(),
+        }
+    }
+
+    pub fn bit_shl(a: &ValueWire, b: &ValueWire) -> ValueWire {
+        match b.as_usize() {
+            Some(n) => a.shift_up_const(n),
+            None => panic!("Wire 'b' is not a constant"),
         }
     }
 

--- a/src/value_wire.rs
+++ b/src/value_wire.rs
@@ -177,6 +177,23 @@ impl ValueWire {
         }
     }
 
+    pub fn shift_down_const(&self, amount: usize) -> ValueWire {
+        if amount >= self.bits.len() {
+            return ValueWire::new_const(0, &self.id_gen);
+        }
+
+        let mut bits = Vec::with_capacity(self.bits.len() - amount);
+
+        for i in amount..self.bits.len() {
+            bits.push(self.bits[i].clone());
+        }
+
+        ValueWire {
+            id_gen: self.id_gen.clone(),
+            bits,
+        }
+    }
+
     pub fn mul_bool(a: &Rc<BoolWire>, b: &ValueWire) -> ValueWire {
         let mut bits = Vec::with_capacity(b.bits.len());
 
@@ -378,47 +395,14 @@ impl ValueWire {
 
     pub fn bit_shl(a: &ValueWire, b: &ValueWire) -> ValueWire {
         match b.as_usize() {
-            Some(n) => {
-                let mut bits = Vec::with_capacity(a.bits.len() + n);
-
-                for _ in 0..n {
-                    bits.push(Rc::new(BoolWire {
-                        id_gen: a.id_gen.clone(),
-                        data: BoolData::Const(false),
-                    }));
-                }
-
-                for i in 0..a.bits.len() - 1 {
-                    bits.push(a.bits[i].clone());
-                }
-
-                ValueWire {
-                    id_gen: a.id_gen.clone(),
-                    bits,
-                }
-            }
+            Some(n) => a.shift_up_const(n),
             None => panic!("Wire 'b' is not a constant"),
         }
     }
 
     pub fn bit_shr(a: &ValueWire, b: &ValueWire) -> ValueWire {
         match b.as_usize() {
-            Some(n) => {
-                if n >= a.bits.len() {
-                    return ValueWire::new_const(0, &a.id_gen);
-                }
-
-                let mut bits = Vec::with_capacity(a.bits.len() - n);
-
-                for i in n..a.bits.len() {
-                    bits.push(a.bits[i].clone());
-                }
-
-                ValueWire {
-                    id_gen: a.id_gen.clone(),
-                    bits,
-                }
-            }
+            Some(n) => a.shift_down_const(n),
             None => panic!("Wire 'b' is not a constant"),
         }
     }

--- a/src/value_wire.rs
+++ b/src/value_wire.rs
@@ -378,7 +378,47 @@ impl ValueWire {
 
     pub fn bit_shl(a: &ValueWire, b: &ValueWire) -> ValueWire {
         match b.as_usize() {
-            Some(n) => a.shift_up_const(n),
+            Some(n) => {
+                let mut bits = Vec::with_capacity(a.bits.len() + n);
+
+                for _ in 0..n {
+                    bits.push(Rc::new(BoolWire {
+                        id_gen: a.id_gen.clone(),
+                        data: BoolData::Const(false),
+                    }));
+                }
+
+                for i in 0..a.bits.len() - 1 {
+                    bits.push(a.bits[i].clone());
+                }
+
+                ValueWire {
+                    id_gen: a.id_gen.clone(),
+                    bits,
+                }
+            }
+            None => panic!("Wire 'b' is not a constant"),
+        }
+    }
+
+    pub fn bit_shr(a: &ValueWire, b: &ValueWire) -> ValueWire {
+        match b.as_usize() {
+            Some(n) => {
+                if n >= a.bits.len() {
+                    return ValueWire::new_const(0, &a.id_gen);
+                }
+
+                let mut bits = Vec::with_capacity(a.bits.len() - n);
+
+                for i in n..a.bits.len() {
+                    bits.push(a.bits[i].clone());
+                }
+
+                ValueWire {
+                    id_gen: a.id_gen.clone(),
+                    bits,
+                }
+            }
             None => panic!("Wire 'b' is not a constant"),
         }
     }

--- a/tests/test_circuits.rs
+++ b/tests/test_circuits.rs
@@ -139,11 +139,9 @@ fn test_2bit_shr() {
 
     let bristol_string = circuit.get_bristol_string().unwrap();
 
-    dbg!(&bristol_string);
-
     assert_eq!(
         bristol_string,
-        vec!["1 3", "1 2", "1 1", "", "1 1 0 2 COPY", ""].join("\n")
+        vec!["2 4", "1 2", "1 2", "", "1 1 0 3 COPY", "2 1 0 0 2 XOR", ""].join("\n")
     );
 }
 

--- a/tests/test_circuits.rs
+++ b/tests/test_circuits.rs
@@ -125,6 +125,29 @@ fn test_2bit_shl() {
 }
 
 #[test]
+fn test_2bit_shr() {
+    let id_gen = Rc::new(RefCell::new(IdGenerator::new()));
+
+    let a = ValueWire::new_input("a", 2, &id_gen);
+    let b = ValueWire::new_const(1, &id_gen);
+
+    let c = ValueWire::bit_shr(&a, &b);
+
+    let outputs = vec![CircuitOutput::new("c", c)];
+
+    let circuit = generate_bristol(&outputs);
+
+    let bristol_string = circuit.get_bristol_string().unwrap();
+
+    dbg!(&bristol_string);
+
+    assert_eq!(
+        bristol_string,
+        vec!["1 3", "1 2", "1 1", "", "1 1 0 2 COPY", ""].join("\n")
+    );
+}
+
+#[test]
 fn test_4bit_mul() {
     test_4bit_binary_op(ValueWire::mul, |a, b| (a * b) & 0xf);
 }

--- a/tests/test_circuits.rs
+++ b/tests/test_circuits.rs
@@ -104,6 +104,27 @@ fn test_2bit_mul() {
 }
 
 #[test]
+fn test_2bit_shl() {
+    let id_gen = Rc::new(RefCell::new(IdGenerator::new()));
+
+    let a = ValueWire::new_input("a", 2, &id_gen);
+    let b = ValueWire::new_const(1, &id_gen);
+
+    let c = ValueWire::bit_shl(&a, &b);
+
+    let outputs = vec![CircuitOutput::new("c", c)];
+
+    let circuit = generate_bristol(&outputs);
+
+    let bristol_string = circuit.get_bristol_string().unwrap();
+
+    assert_eq!(
+        bristol_string,
+        vec!["2 4", "1 2", "1 2", "", "2 1 0 0 3 XOR", "1 1 1 2 COPY", ""].join("\n")
+    );
+}
+
+#[test]
 fn test_4bit_mul() {
     test_4bit_binary_op(ValueWire::mul, |a, b| (a * b) & 0xf);
 }

--- a/tests/test_circuits.rs
+++ b/tests/test_circuits.rs
@@ -120,7 +120,16 @@ fn test_2bit_shl() {
 
     assert_eq!(
         bristol_string,
-        vec!["2 4", "1 2", "1 2", "", "2 1 0 0 3 XOR", "1 1 1 2 COPY", ""].join("\n")
+        vec![
+            "2 4", //
+            "1 2",
+            "1 2",
+            "",
+            "2 1 0 0 3 XOR",
+            "1 1 1 2 COPY",
+            ""
+        ]
+        .join("\n")
     );
 }
 
@@ -141,7 +150,16 @@ fn test_2bit_shr() {
 
     assert_eq!(
         bristol_string,
-        vec!["2 4", "1 2", "1 2", "", "1 1 0 3 COPY", "2 1 0 0 2 XOR", ""].join("\n")
+        vec![
+            "2 4", //
+            "1 2",
+            "1 2",
+            "",
+            "1 1 0 3 COPY",
+            "2 1 0 0 2 XOR",
+            ""
+        ]
+        .join("\n")
     );
 }
 


### PR DESCRIPTION
This PR adds support for shift operators (left and right) with constants. Two functions have been added to the `ValueWire` impl: `bit_shr` and `bit_shl`.

Tests have been added to test shift operations with 2-bit and 4-bit numbers.

Some functions that could be used elsewhere in the code have also been implemented:
* `ValueWire::as_usize`: converts a `ValueWire` to a `usize`.
* `ValueWire::shift_down_const`: like the existing `shift_up_const`, used by `bit_shr`.
* `test_4bit_binary_op_with_const`: tests 4-bit binary operations with constants (it can potentially be used by exp).