### PR TITLE
Fix key ordering bug

### DIFF
--- a/src/boolify.rs
+++ b/src/boolify.rs
@@ -12,7 +12,17 @@ pub fn boolify(arith_circuit: &BristolCircuit, bit_width: usize) -> BristolCircu
     let id_gen = IdGenerator::new_rc_refcell();
     let mut wires: Vec<Option<ValueWire>> = vec![None; arith_circuit.wire_count];
 
-    for (name, i) in &arith_circuit.info.input_name_to_wire_index {
+    let mut ordered_inputs = arith_circuit
+        .info
+        .input_name_to_wire_index
+        .iter()
+        .collect::<Vec<_>>();
+
+    // It's important to create the ValueWires in this order so that the resulting boolean circuit
+    // preserves the order of the inputs.
+    ordered_inputs.sort_by_key(|(_, wire_index)| **wire_index);
+
+    for (name, i) in ordered_inputs {
         wires[*i] = Some(ValueWire::new_input(name, bit_width, &id_gen));
     }
 

--- a/src/generate_bristol.rs
+++ b/src/generate_bristol.rs
@@ -129,11 +129,11 @@ fn collect_inputs(
     visited: &mut HashSet<usize>,
     bool: &BoolWire,
 ) {
-    if let Some(id) = bool.id() {
-        if !visited.insert(id) {
-            return;
-        }
-    } else {
+    let Some(id) = bool.id() else {
+        return;
+    };
+
+    if !visited.insert(id) {
         return;
     }
 


### PR DESCRIPTION
In this line of the original code:

```rs
for (name, i) in &arith_circuit.info.input_name_to_wire_index
```

it's iterating over a `HashMap`. The iteration order of `HashMap` is intentionally inconsistent in rust:

> By default, HashMap uses a hashing algorithm selected to provide resistance against HashDoS attacks. The algorithm is randomly seeded, and a reasonable best-effort is made to generate this seed from a high quality, secure source of randomness provided by the host without blocking the program. Because of this, the randomness of the seed depends on the output quality of the system’s random number coroutine when the seed is created. In particular, seeds generated when the system’s entropy pool is abnormally low such as during system boot may be of a lower quality.
> https://doc.rust-lang.org/std/collections/struct.HashMap.html?utm_source=chatgpt.com

This lead to an inconsistent order of the inputs in the resulting circuit, because the `id_gen` allocates an id for the `ValueWire` in that order.

This PR solves that by first sorting by the wire id (of the incoming arithmetic circuit).