### PR TITLE
feat: add exp operator with const

### DIFF
--- a/src/boolify.rs
+++ b/src/boolify.rs
@@ -86,7 +86,7 @@ pub fn boolify(arith_circuit: &BristolCircuit, bit_width: usize) -> BristolCircu
                 "AMul" => ValueWire::mul(a, b),
                 "ADiv" => ValueWire::div(a, b),
                 "AMod" => ValueWire::mod_(a, b),
-                "AExp" => panic!("Not implemented: exp"), // TODO
+                "AExp" => ValueWire::exp(a, b),
                 "AEq" => to_value(&ValueWire::equal(a, b)),
                 "ANeq" => to_value(&ValueWire::not_equal(a, b)),
                 "ABoolAnd" => to_value(&ValueWire::bool_and(a, b)),

--- a/src/value_wire.rs
+++ b/src/value_wire.rs
@@ -235,6 +235,21 @@ impl ValueWire {
         tree_sum(&sum_terms, &a.id_gen)
     }
 
+    pub fn exp(a: &ValueWire, b: &ValueWire) -> ValueWire {
+        match b.as_usize() {
+            Some(n) => {
+                let mut e = a.clone();
+
+                for _i in 0..n - 1 {
+                    e = ValueWire::mul(&e, &e);
+                }
+
+                return e;
+            }
+            None => panic!("Wire 'b' is not a constant"),
+        }
+    }
+
     fn split_at(&self, split_point: usize) -> (ValueWire, ValueWire) {
         if self.bits.len() <= split_point {
             return (self.clone(), ValueWire::new_const(0, &self.id_gen));

--- a/src/value_wire.rs
+++ b/src/value_wire.rs
@@ -238,13 +238,23 @@ impl ValueWire {
     pub fn exp(a: &ValueWire, b: &ValueWire) -> ValueWire {
         match b.as_usize() {
             Some(n) => {
-                let mut e = a.clone();
+                if n == 0 {
+                    // Base case: any number to the power of 0 is 1.
+                    return ValueWire::new_const(1, &a.id_gen);
+                } else if n == 1 {
+                    return a.clone();
+                } else if n % 2 == 0 {
+                    // If n is even, compute (a * a)^(n / 2).
+                    let half = ValueWire::mul(a, a);
 
-                for _i in 0..n - 1 {
-                    e = ValueWire::mul(&e, &e);
+                    return ValueWire::exp(&half, &ValueWire::new_const(n / 2, &a.id_gen));
+                } else {
+                    // If n is odd: compute a * (a * a)^((n - 1) / 2).
+                    let half = ValueWire::mul(a, a);
+                    let reduced = ValueWire::exp(&half, &ValueWire::new_const((n - 1) / 2, &a.id_gen));
+
+                    return ValueWire::mul(a, &reduced);
                 }
-
-                return e;
             }
             None => panic!("Wire 'b' is not a constant"),
         }

--- a/tests/test_circuits.rs
+++ b/tests/test_circuits.rs
@@ -104,6 +104,38 @@ fn test_2bit_mul() {
 }
 
 #[test]
+fn test_2bit_exp() {
+    let id_gen = Rc::new(RefCell::new(IdGenerator::new()));
+
+    let a = ValueWire::new_input("a", 2, &id_gen);
+    let b = ValueWire::new_const(2, &id_gen);
+
+    let c = ValueWire::exp(&a, &b);
+
+    let outputs = vec![CircuitOutput::new("c", c)];
+
+    let circuit = generate_bristol(&outputs);
+
+    let bristol_string = circuit.get_bristol_string().unwrap();
+
+    assert_eq!(
+        bristol_string,
+        vec![
+            "4 6",
+            "1 2",
+            "1 2",
+            "",
+            "2 1 1 1 5 AND",
+            "2 1 1 0 2 AND",
+            "2 1 0 1 3 AND",
+            "2 1 2 3 4 XOR",
+            ""
+        ]
+        .join("\n")
+    );
+}
+
+#[test]
 fn test_2bit_shl() {
     let id_gen = Rc::new(RefCell::new(IdGenerator::new()));
 

--- a/tests/test_circuits.rs
+++ b/tests/test_circuits.rs
@@ -201,6 +201,11 @@ fn test_4bit_mul() {
 }
 
 #[test]
+fn test_4bit_exp() {
+    test_4bit_binary_op_with_const(ValueWire::exp, |a, b| a.pow(b.try_into().unwrap()) & 0xf);
+}
+
+#[test]
 fn test_4bit_shl() {
     test_4bit_binary_op_with_const(ValueWire::bit_shl, |a, b| (a << b) & 0xf);
 }
@@ -339,7 +344,7 @@ where
     let circuit = generate_bristol(&outputs);
 
     for a in 0..16 {
-        let inputs = vec![("a", a), ("b", 2)]
+        let inputs = vec![("a", a), ("b", b.as_usize().unwrap())]
             .into_iter()
             .map(|(name, value)| (name.to_string(), value))
             .collect::<HashMap<String, usize>>();


### PR DESCRIPTION
This PR adds support for exponentiation with constant. It introduces an efficient implementation using the "[Exponentiation by squaring](https://en.wikipedia.org/wiki/Exponentiation_by_squaring)" method. An `exp` function has been added to the ValueWire impl.

Tests have been added to test the exp operations with 2-bit and 4-bit numbers.