### PR TITLE
Improve compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@ into *boolean* [bristol fashion](https://nigelsmart.github.io/MPC-Circuits/) cir
 2 4 4
 1 4
 
-2 1 3 7 21 XOR
-2 1 2 6 8 XOR
-2 1 3 7 9 AND
-2 1 8 9 20 XOR
-2 1 1 5 10 XOR
-2 1 2 6 11 AND
+2 1 0 4 18 XOR
+2 1 1 5 8 XOR
+2 1 0 4 9 AND
+2 1 8 9 19 XOR
+2 1 2 6 10 XOR
+2 1 1 5 11 AND
 2 1 9 8 12 AND
-2 1 11 12 13 OR
-2 1 10 13 19 XOR
-2 1 0 4 14 XOR
-2 1 1 5 15 AND
+2 1 11 12 13 XOR
+2 1 10 13 20 XOR
+2 1 3 7 14 XOR
+2 1 2 6 15 AND
 2 1 13 10 16 AND
-2 1 15 16 17 OR
-2 1 14 17 18 XOR
+2 1 15 16 17 XOR
+2 1 14 17 21 XOR
 ```
 
 both circuits represent the addition of two numbers, but the arithmetic circuit simply uses one built-in addition gate, and the boolean circuit achieves (4-bit) addition using only boolean operations.

--- a/src/bool_wire.rs
+++ b/src/bool_wire.rs
@@ -85,6 +85,7 @@ impl BoolWire {
                     data: BoolData::Const(!b),
                 })
             }
+            BoolData::Not(_, a) => return a.clone(),
             _ => (),
         }
 

--- a/src/bool_wire.rs
+++ b/src/bool_wire.rs
@@ -6,7 +6,7 @@ pub enum BoolData {
     Const(bool),
     Input(usize, Rc<CircuitInput>),
     And(usize, Rc<BoolWire>, Rc<BoolWire>),
-    Not(usize, Rc<BoolWire>),
+    Inv(usize, Rc<BoolWire>), // Aka NOT
     Xor(usize, Rc<BoolWire>, Rc<BoolWire>),
     Copy(usize, Rc<BoolWire>),
 }
@@ -29,7 +29,7 @@ impl BoolWire {
             BoolData::Const(_) => None,
             BoolData::Input(id, _) => Some(*id),
             BoolData::And(id, _, _) => Some(*id),
-            BoolData::Not(id, _) => Some(*id),
+            BoolData::Inv(id, _) => Some(*id),
             BoolData::Xor(id, _, _) => Some(*id),
             BoolData::Copy(id, _) => Some(*id),
         }
@@ -73,7 +73,7 @@ impl BoolWire {
 
         Rc::new(BoolWire {
             id_gen: a.id_gen.clone(),
-            data: BoolData::Not(id, BoolWire::and(&BoolWire::not(a), &BoolWire::not(b))),
+            data: BoolData::Inv(id, BoolWire::and(&BoolWire::not(a), &BoolWire::not(b))),
         })
     }
 
@@ -85,7 +85,7 @@ impl BoolWire {
                     data: BoolData::Const(!b),
                 })
             }
-            BoolData::Not(_, a) => return a.clone(),
+            BoolData::Inv(_, a) => return a.clone(),
             _ => (),
         }
 
@@ -93,7 +93,7 @@ impl BoolWire {
 
         Rc::new(BoolWire {
             id_gen: a.id_gen.clone(),
-            data: BoolData::Not(id, a.clone()),
+            data: BoolData::Inv(id, a.clone()),
         })
     }
 

--- a/src/bool_wire.rs
+++ b/src/bool_wire.rs
@@ -6,7 +6,6 @@ pub enum BoolData {
     Const(bool),
     Input(usize, Rc<CircuitInput>),
     And(usize, Rc<BoolWire>, Rc<BoolWire>),
-    Or(usize, Rc<BoolWire>, Rc<BoolWire>),
     Not(usize, Rc<BoolWire>),
     Xor(usize, Rc<BoolWire>, Rc<BoolWire>),
     Copy(usize, Rc<BoolWire>),
@@ -30,7 +29,6 @@ impl BoolWire {
             BoolData::Const(_) => None,
             BoolData::Input(id, _) => Some(*id),
             BoolData::And(id, _, _) => Some(*id),
-            BoolData::Or(id, _, _) => Some(*id),
             BoolData::Not(id, _) => Some(*id),
             BoolData::Xor(id, _, _) => Some(*id),
             BoolData::Copy(id, _) => Some(*id),
@@ -75,7 +73,7 @@ impl BoolWire {
 
         Rc::new(BoolWire {
             id_gen: a.id_gen.clone(),
-            data: BoolData::Or(id, a.clone(), b.clone()),
+            data: BoolData::Not(id, BoolWire::and(&BoolWire::not(a), &BoolWire::not(b))),
         })
     }
 

--- a/src/boolify.rs
+++ b/src/boolify.rs
@@ -62,7 +62,7 @@ pub fn boolify(arith_circuit: &BristolCircuit, bit_width: usize) -> BristolCircu
             wires[out_id] = Some(match gate.op.as_str() {
                 "AUnaryAdd" => in_.clone(),
                 "AUnarySub" => ValueWire::negate(in_),
-                "ANot" => to_value(&BoolWire::not(&in_.to_bool())),
+                "ANot" => to_value(&BoolWire::inv(&in_.to_bool())),
                 "ABitNot" => ValueWire::bit_not(in_),
                 _ => unreachable!(),
             });

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -41,13 +41,6 @@ pub fn eval(circuit: &BristolCircuit, inputs: &HashMap<String, usize>) -> HashMa
 
                 wires[c] = wires[a] && wires[b];
             }
-            "OR" => {
-                let a = gate.inputs[0];
-                let b = gate.inputs[1];
-                let c = gate.outputs[0];
-
-                wires[c] = wires[a] || wires[b];
-            }
             "XOR" => {
                 let a = gate.inputs[0];
                 let b = gate.inputs[1];
@@ -55,7 +48,7 @@ pub fn eval(circuit: &BristolCircuit, inputs: &HashMap<String, usize>) -> HashMa
 
                 wires[c] = wires[a] ^ wires[b];
             }
-            "NOT" => {
+            "INV" => {
                 let a = gate.inputs[0];
                 let c = gate.outputs[0];
 

--- a/src/generate_bristol.rs
+++ b/src/generate_bristol.rs
@@ -148,7 +148,7 @@ fn collect_inputs(mut bits: VecDeque<&BoolWire>) -> BTreeMap<usize, Rc<CircuitIn
                 bits.push_back(&b);
             }
             BoolData::Const(_) => (),
-            BoolData::Not(_, a) | BoolData::Copy(_, a) => {
+            BoolData::Inv(_, a) | BoolData::Copy(_, a) => {
                 bits.push_back(&a);
             }
         }
@@ -282,11 +282,11 @@ fn generate_gates(
                         op,
                     });
                 }
-                BoolData::Not(_, a) | BoolData::Copy(_, a) => {
+                BoolData::Inv(_, a) | BoolData::Copy(_, a) => {
                     let a_id = wire_id_mapper.get(a.id().expect("Input should have an id"));
                     let out_id = wire_id_mapper.get(bit.id().expect("Input should have an id"));
                     let op = match &bit.data {
-                        BoolData::Not(_, _) => "NOT".to_string(),
+                        BoolData::Inv(_, _) => "INV".to_string(),
                         BoolData::Copy(_, _) => "COPY".to_string(),
                         _ => unreachable!(),
                     };
@@ -319,7 +319,7 @@ fn generate_gates(
                         }
                     }
                 }
-                BoolData::Not(_, a) | BoolData::Copy(_, a) => {
+                BoolData::Inv(_, a) | BoolData::Copy(_, a) => {
                     if let Some(a_id) = a.id() {
                         if generated_ids.insert(a_id) {
                             stack.push((a.clone(), false));

--- a/src/generate_bristol.rs
+++ b/src/generate_bristol.rs
@@ -42,6 +42,10 @@ pub fn generate_bristol(outputs: &Vec<CircuitOutput>) -> BristolCircuit {
     let special_false = BoolWire::xor(&first_wire, &first_wire);
     let special_true = BoolWire::inv(&special_false);
 
+    // Special true/false often gets copied. By ensuring false is an inversion, we can produce each
+    // copy with a single inversion instead of two.
+    let special_false = BoolWire::inv_with_new_id(&special_true);
+
     let mut outputs = outputs.clone();
     for output in outputs.iter_mut() {
         for bit in output.value.bits.iter_mut() {

--- a/src/generate_bristol.rs
+++ b/src/generate_bristol.rs
@@ -143,7 +143,7 @@ fn collect_inputs(mut bits: VecDeque<&BoolWire>) -> BTreeMap<usize, Rc<CircuitIn
                     assert!(std::ptr::eq(&*prev, &**input));
                 }
             }
-            BoolData::And(_, a, b) | BoolData::Or(_, a, b) | BoolData::Xor(_, a, b) => {
+            BoolData::And(_, a, b) | BoolData::Xor(_, a, b) => {
                 bits.push_back(&a);
                 bits.push_back(&b);
             }
@@ -267,13 +267,12 @@ fn generate_gates(
             // Process the node after its children have been processed.
             match &bit.data {
                 BoolData::Input(_, _) => { /* nothing to do for inputs */ }
-                BoolData::And(_, a, b) | BoolData::Or(_, a, b) | BoolData::Xor(_, a, b) => {
+                BoolData::And(_, a, b) | BoolData::Xor(_, a, b) => {
                     let a_id = wire_id_mapper.get(a.id().expect("Input should have an id"));
                     let b_id = wire_id_mapper.get(b.id().expect("Input should have an id"));
                     let out_id = wire_id_mapper.get(bit.id().expect("Input should have an id"));
                     let op = match &bit.data {
                         BoolData::And(_, _, _) => "AND".to_string(),
-                        BoolData::Or(_, _, _) => "OR".to_string(),
                         BoolData::Xor(_, _, _) => "XOR".to_string(),
                         _ => unreachable!(),
                     };
@@ -307,7 +306,7 @@ fn generate_gates(
             stack.push((bit.clone(), true));
             match &bit.data {
                 BoolData::Input(_, _) => { /* no children */ }
-                BoolData::And(_, a, b) | BoolData::Or(_, a, b) | BoolData::Xor(_, a, b) => {
+                BoolData::And(_, a, b) | BoolData::Xor(_, a, b) => {
                     // Push b then a (so that a is processed first).
                     if let Some(b_id) = b.id() {
                         if generated_ids.insert(b_id) {

--- a/src/value_wire.rs
+++ b/src/value_wire.rs
@@ -305,7 +305,7 @@ impl ValueWire {
         let (eq1, lt1) = ValueWire::cmp(&a1, &b1);
 
         let eq = BoolWire::and(&eq0, &eq1);
-        let lt = BoolWire::or(&lt1, &BoolWire::and(&eq1, &lt0));
+        let lt = BoolWire::xor(&lt1, &BoolWire::and(&eq1, &lt0));
 
         (eq, lt)
     }

--- a/src/value_wire.rs
+++ b/src/value_wire.rs
@@ -99,7 +99,7 @@ impl ValueWire {
             let sum = BoolWire::xor(&a_bit, &b_bit);
 
             let new_carry =
-                BoolWire::or(&BoolWire::and(&a_bit, &b_bit), &BoolWire::and(&carry, &sum));
+                BoolWire::xor(&BoolWire::and(&a_bit, &b_bit), &BoolWire::and(&carry, &sum));
 
             bits.push(BoolWire::xor(&sum, &carry));
             carry = new_carry;

--- a/src/value_wire.rs
+++ b/src/value_wire.rs
@@ -112,7 +112,7 @@ impl ValueWire {
     }
 
     pub fn bit_not(a: &ValueWire) -> ValueWire {
-        let bits = a.bits.iter().map(|bit| BoolWire::not(bit)).collect();
+        let bits = a.bits.iter().map(|bit| BoolWire::inv(bit)).collect();
 
         ValueWire {
             id_gen: a.id_gen.clone(),
@@ -293,8 +293,8 @@ impl ValueWire {
 
         if size == 1 {
             return (
-                BoolWire::not(&BoolWire::xor(&a.at(0), &b.at(0))),
-                BoolWire::and(&BoolWire::not(&a.at(0)), &b.at(0)),
+                BoolWire::inv(&BoolWire::xor(&a.at(0), &b.at(0))),
+                BoolWire::and(&BoolWire::inv(&a.at(0)), &b.at(0)),
             );
         }
 
@@ -321,11 +321,11 @@ impl ValueWire {
     }
 
     pub fn less_than_or_eq(a: &ValueWire, b: &ValueWire) -> Rc<BoolWire> {
-        BoolWire::not(&ValueWire::greater_than(a, b))
+        BoolWire::inv(&ValueWire::greater_than(a, b))
     }
 
     pub fn greater_than_or_eq(a: &ValueWire, b: &ValueWire) -> Rc<BoolWire> {
-        BoolWire::not(&ValueWire::less_than(a, b))
+        BoolWire::inv(&ValueWire::less_than(a, b))
     }
 
     pub fn equal(a: &ValueWire, b: &ValueWire) -> Rc<BoolWire> {
@@ -339,7 +339,7 @@ impl ValueWire {
         }
 
         if size == 1 {
-            return BoolWire::not(&BoolWire::xor(&a.at(0), &b.at(0)));
+            return BoolWire::inv(&BoolWire::xor(&a.at(0), &b.at(0)));
         }
 
         let (a0, a1) = a.split_at(size / 2);
@@ -352,7 +352,7 @@ impl ValueWire {
     }
 
     pub fn not_equal(a: &ValueWire, b: &ValueWire) -> Rc<BoolWire> {
-        BoolWire::not(&ValueWire::equal(a, b))
+        BoolWire::inv(&ValueWire::equal(a, b))
     }
 
     pub fn to_bool(&self) -> Rc<BoolWire> {
@@ -381,7 +381,7 @@ impl ValueWire {
     }
 
     pub fn bool_not(a: &ValueWire) -> Rc<BoolWire> {
-        BoolWire::not(&a.to_bool())
+        BoolWire::inv(&a.to_bool())
     }
 
     pub fn bool_xor(a: &ValueWire, b: &ValueWire) -> Rc<BoolWire> {
@@ -449,7 +449,7 @@ impl ValueWire {
         for i in 1..size {
             shifts_valid.push(BoolWire::and(
                 &shifts_valid[i - 1],
-                &BoolWire::not(&b.at(size - i)),
+                &BoolWire::inv(&b.at(size - i)),
             ));
         }
 
@@ -468,7 +468,7 @@ impl ValueWire {
 
             rem = ValueWire::bit_xor(
                 &ValueWire::mul_bool(&apply, &apply_rem),
-                &ValueWire::mul_bool(&BoolWire::not(&apply), &rem),
+                &ValueWire::mul_bool(&BoolWire::inv(&apply), &rem),
             );
         }
 

--- a/tests/test_circuits.rs
+++ b/tests/test_circuits.rs
@@ -53,18 +53,20 @@ fn test_8bit_xor_and_1() {
     assert_eq!(
         bristol_string,
         vec![
-            "8 24",
+            "10 26", //
             "2 8 8",
             "1 8",
             "",
-            "2 1 0 8 16 XOR",
-            "2 1 0 0 17 XOR",
-            "1 1 17 18 COPY",
-            "1 1 17 19 COPY",
-            "1 1 17 20 COPY",
-            "1 1 17 21 COPY",
-            "1 1 17 22 COPY",
-            "1 1 17 23 COPY",
+            "2 1 0 8 18 XOR",
+            "2 1 0 0 16 XOR",
+            "1 1 16 17 INV",
+            "1 1 17 19 INV",
+            "1 1 17 20 INV",
+            "1 1 17 21 INV",
+            "1 1 17 22 INV",
+            "1 1 17 23 INV",
+            "1 1 17 24 INV",
+            "1 1 17 25 INV",
             "",
         ]
         .join("\n")
@@ -153,12 +155,15 @@ fn test_2bit_shl() {
     assert_eq!(
         bristol_string,
         vec![
-            "2 4", //
+            "5 7", //
             "1 2",
             "1 2",
             "",
             "2 1 0 0 2 XOR",
-            "1 1 0 3 COPY",
+            "1 1 2 3 INV",
+            "1 1 3 5 INV",
+            "1 1 0 4 INV",
+            "1 1 4 6 INV",
             ""
         ]
         .join("\n")
@@ -183,12 +188,15 @@ fn test_2bit_shr() {
     assert_eq!(
         bristol_string,
         vec![
-            "2 4", //
+            "5 7", //
             "1 2",
             "1 2",
             "",
-            "1 1 1 2 COPY",
+            "1 1 1 2 INV",
+            "1 1 2 5 INV",
             "2 1 0 0 3 XOR",
+            "1 1 3 4 INV",
+            "1 1 4 6 INV",
             ""
         ]
         .join("\n")


### PR DESCRIPTION
## What is this PR doing?

Improves compatibility of generated bristol circuits:
- No longer produces `OR` (uses or(a,b)=inv(and(inv(a), inv(b))) when needed)
- No longer produces `COPY` (uses copy(a)=inv(inv(a)) when needed)
- Uses `INV` instead of `NOT` (same meaning)

Also added `inv(inv(a))=a` optimization (and prevented it when needed to achieve copying).

I also took the opportunity to reduce our use of `or` internally in two places where `xor` is equivalent:
- When computing the next carry bit during addition, because `a&b` and `a^b` cannot be true simultaneously
- When computing less-than, because `lt1` and `eq1` cannot be true simultaneously
- (These functions are also covered by exhaustive tests of the 4-bit case)

## How can these changes be manually tested?

`cargo test`

## Does this PR resolve or contribute to any issues?

Resolves https://www.notion.so/pse-team/Avoid-OR-gates-in-boolify-1b3d57e8dd7e80f6ad33f0d5ea8482c9?pvs=4

## Checklist
- [x] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
