### PR TITLE
Fix gate ordering bug

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use bristol_circuit::BristolCircuit;
 
 pub fn eval(circuit: &BristolCircuit, inputs: &HashMap<String, usize>) -> HashMap<String, usize> {
-    let mut wires = vec![false; circuit.wire_count];
+    let mut wires: Vec<Option<bool>> = vec![None; circuit.wire_count];
 
     let mut sorted_inputs = circuit
         .info
@@ -28,7 +28,7 @@ pub fn eval(circuit: &BristolCircuit, inputs: &HashMap<String, usize>) -> HashMa
         }
 
         for j in 0..width {
-            wires[id_start + j] = (value >> j) & 1 == 1;
+            wires[id_start + j] = Some((value >> j) & 1 == 1);
         }
     }
 
@@ -39,26 +39,26 @@ pub fn eval(circuit: &BristolCircuit, inputs: &HashMap<String, usize>) -> HashMa
                 let b = gate.inputs[1];
                 let c = gate.outputs[0];
 
-                wires[c] = wires[a] && wires[b];
+                wires[c] = Some(wires[a].unwrap() && wires[b].unwrap());
             }
             "XOR" => {
                 let a = gate.inputs[0];
                 let b = gate.inputs[1];
                 let c = gate.outputs[0];
 
-                wires[c] = wires[a] ^ wires[b];
+                wires[c] = Some(wires[a].unwrap() ^ wires[b].unwrap());
             }
             "INV" => {
                 let a = gate.inputs[0];
                 let c = gate.outputs[0];
 
-                wires[c] = !wires[a];
+                wires[c] = Some(!wires[a].unwrap());
             }
             "COPY" => {
                 let a = gate.inputs[0];
                 let c = gate.outputs[0];
 
-                wires[c] = wires[a];
+                wires[c] = Some(wires[a].unwrap());
             }
             _ => {
                 panic!("unknown gate operation: {}", gate.op);
@@ -85,7 +85,7 @@ pub fn eval(circuit: &BristolCircuit, inputs: &HashMap<String, usize>) -> HashMa
         let mut value = 0;
 
         for j in 0..width {
-            value |= (wires[id_start + j] as usize) << j;
+            value |= (wires[id_start + j].unwrap() as usize) << j;
         }
 
         outputs.insert(name.clone(), value);

--- a/src/generate_bristol.rs
+++ b/src/generate_bristol.rs
@@ -260,9 +260,11 @@ fn generate_gates(
     let mut stack: Vec<(Rc<BoolWire>, bool)> = vec![(start.clone(), false)];
 
     while let Some((bit, visited)) = stack.pop() {
-        let out_id = wire_id_mapper.get(bit.id().expect("Output should have an id"));
+        let Some(bit_id) = bit.id() else {
+            continue;
+        };
 
-        if generated_ids.contains(&out_id) {
+        if generated_ids.contains(&bit_id) {
             continue;
         }
 
@@ -273,6 +275,7 @@ fn generate_gates(
                 BoolData::And(_, a, b) | BoolData::Xor(_, a, b) => {
                     let a_id = wire_id_mapper.get(a.id().expect("Input should have an id"));
                     let b_id = wire_id_mapper.get(b.id().expect("Input should have an id"));
+                    let out_id = wire_id_mapper.get(bit_id);
                     let op = match &bit.data {
                         BoolData::And(_, _, _) => "AND".to_string(),
                         BoolData::Xor(_, _, _) => "XOR".to_string(),
@@ -286,6 +289,7 @@ fn generate_gates(
                 }
                 BoolData::Inv(_, a) => {
                     let a_id = wire_id_mapper.get(a.id().expect("Input should have an id"));
+                    let out_id = wire_id_mapper.get(bit_id);
                     let op = match &bit.data {
                         BoolData::Inv(_, _) => "INV".to_string(),
                         _ => unreachable!(),
@@ -301,7 +305,7 @@ fn generate_gates(
                 }
             }
 
-            generated_ids.insert(out_id);
+            generated_ids.insert(bit_id);
         } else {
             // First time seeing this node:
             // Push the node back marked as visited, then push its children.

--- a/tests/test_circuits.rs
+++ b/tests/test_circuits.rs
@@ -303,6 +303,66 @@ fn test_4bit_negate() {
     test_4bit_unary_op(ValueWire::negate, |a| (16 - a) & 0xf);
 }
 
+#[test]
+fn test_4bit_which_is_larger() {
+    test_4bit_binary_op(
+        |a, b| {
+            // Based on summon generation for:
+            // export default (a, b) => a === b ? 0 : a > b ? 1 : 2;
+
+            // 2 1 0 1 2 AEq
+            let w2 = ValueWire::equal(a, b);
+
+            // 2 1 0 1 3 AGt
+            let w3 = ValueWire::greater_than(a, b);
+
+            // 1 1 2 4 ANot
+            let w4 = BoolWire::inv(&w2);
+
+            // 1 1 3 5 ANot
+            let w5 = BoolWire::inv(&w3);
+
+            // 2 1 4 5 6 ABoolAnd
+            let w6 = BoolWire::and(&w4, &w5);
+
+            // 2 1 6 7 8 AMul
+            let w8 = ValueWire::mul(
+                &BoolWire::as_value(&w6).resize(4),
+                &ValueWire::new_const(2, &a.id_gen), // w7 is 2
+            );
+
+            // 2 1 2 6 9 ABoolOr
+            let w9 = BoolWire::or(&w2, &w6);
+
+            // 2 1 9 8 10 AMul
+            let w10 = ValueWire::mul(
+                &BoolWire::as_value(&w9).resize(4), //
+                &w8,
+            );
+
+            // 2 1 4 3 11 ABoolAnd
+            let w11 = BoolWire::and(&w4, &w3);
+
+            // 2 1 10 11 12 AAdd
+            let w12 = ValueWire::add(
+                &w10,
+                &BoolWire::as_value(&w11).resize(4), //
+            );
+
+            w12
+        },
+        |a, b| {
+            if a == b {
+                0 // neither is larger
+            } else if a > b {
+                1 // input 1 is larger
+            } else {
+                2 // input 2 is larger
+            }
+        },
+    );
+}
+
 fn test_4bit_binary_op<F, G>(wire_op: F, op: G)
 where
     F: Fn(&ValueWire, &ValueWire) -> ValueWire,
@@ -318,6 +378,7 @@ where
     let outputs = vec![CircuitOutput::new("c", c)];
 
     let circuit = generate_bristol(&outputs);
+    println!("{}", circuit.get_bristol_string().unwrap());
 
     for a in 0..16 {
         for b in 0..16 {

--- a/tests/test_circuits.rs
+++ b/tests/test_circuits.rs
@@ -309,6 +309,7 @@ fn test_4bit_which_is_larger() {
         |a, b| {
             // Based on summon generation for:
             // export default (a, b) => a === b ? 0 : a > b ? 1 : 2;
+            // (equivalent to mpc-hello circuit)
 
             // 2 1 0 1 2 AEq
             let w2 = ValueWire::equal(a, b);
@@ -378,7 +379,6 @@ where
     let outputs = vec![CircuitOutput::new("c", c)];
 
     let circuit = generate_bristol(&outputs);
-    println!("{}", circuit.get_bristol_string().unwrap());
 
     for a in 0..16 {
         for b in 0..16 {


### PR DESCRIPTION
## What is this PR doing?

- Improves circuit testing by panicking when reading from uninitialized wires instead of assuming they are zero
- Adds test based on mpc-hello (which fails before the fix)
- Fix gate ordering bug to ensure dependencies are generated first
  - Previous code made the mistake of thinking the first visit to each node only needs to occur once, this led to not ensuring the correct order when there are other dependencies on that node later

## How can these changes be manually tested?

1. Checkout the first commit which just adds the test, verify that `cargo test` fails
2. Verify that `cargo test` passes on the full changes

## Does this PR resolve or contribute to any issues?

Contributes to https://www.notion.so/pse-team/Fix-bug-Wire-ID-184-not-found-when-updating-dependencies-of-client-client-demo-1d1d57e8dd7e80bc88c9c2952423fa38?pvs=4
(Resolves the underlying issue but this PR doesn't put the fix into summon-ts where it's needed)

## Checklist
- [x] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
