### PR TITLE
decode constants based on f64

### DIFF
--- a/src/boolify.rs
+++ b/src/boolify.rs
@@ -37,7 +37,7 @@ pub fn boolify(arith_circuit: &BristolCircuit, bit_width: usize) -> BristolCircu
     for const_info in &arith_circuit.info.constants {
         if let Some(v) = const_info.value.as_f64() {
             wires[const_info.address] =
-                Some(ValueWire::new_const(v as usize, &id_gen).resize(bit_width));
+                Some(ValueWire::new_const_f64(v, &id_gen).resize(bit_width));
         } else if let Some(v) = const_info.value.as_bool() {
             wires[const_info.address] =
                 Some(ValueWire::new_const(if v { 1 } else { 0 }, &id_gen).resize(1));

--- a/src/value_wire.rs
+++ b/src/value_wire.rs
@@ -53,6 +53,29 @@ impl ValueWire {
         }
     }
 
+    pub fn new_const_f64(value: f64, id_gen: &Rc<RefCell<IdGenerator>>) -> Self {
+        let mut bits = Vec::new();
+
+        let max_safe_int = 9007199254740991.0;
+        assert!(value >= 0.0 && value == value.trunc() && value <= max_safe_int);
+
+        let mut value = value as u64;
+
+        while value > 0 {
+            bits.push(Rc::new(BoolWire {
+                id_gen: id_gen.clone(),
+                data: BoolData::Const(value & 1 == 1),
+            }));
+
+            value >>= 1;
+        }
+
+        ValueWire {
+            id_gen: id_gen.clone(),
+            bits,
+        }
+    }
+
     pub fn as_usize(&self) -> Option<usize> {
         if self.bits.len() > (usize::BITS as usize) {
             return None;


### PR DESCRIPTION
## What is this PR doing?

Decodes JSON constants based on f64 instead of casting to usize. This becomes relevant in wasm builds for the browser, because that requires 32-bit addressing, which makes usize 32 bits, which is unnecessarily restrictive. This was motivated by the desire to use a one trillion constant in the circuit for Ballpark.

## How can these changes be manually tested?

Run tests, also ideally run summon and summon-ts tests with this dependency.

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
